### PR TITLE
Made Melee Psycasts usable by enemies

### DIFF
--- a/Source/MeleePsycasts/BaseCompAbilityEffect.cs
+++ b/Source/MeleePsycasts/BaseCompAbilityEffect.cs
@@ -22,4 +22,8 @@ public class BaseCompAbilityEffect : CompAbilityEffect
         reason = "MePs.HasMelee".Translate();
         return false;
     }
+	public override bool AICanTargetNow(LocalTargetInfo target)
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
I'm working on a mod to let AI-controlled pawns use psycasts, like Powerful Psycast AI except using the modern ability system and more generic (instead of handling stuff through special hidden jobs, it uses the newer systems that let AI use things like Fire Spew). So it would help if you could merge this and update on Steam, that way enemies will be able to use Melee Psycasts.
